### PR TITLE
Fix/monolith impl

### DIFF
--- a/antifraud-service/src/main/resources/application.yml
+++ b/antifraud-service/src/main/resources/application.yml
@@ -21,6 +21,3 @@ management:
     web:
       exposure:
         include: health, info, metrics
-
-server:
-  port: 8081

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,8 @@ services:
       RABBITMQ_PORT: 5672
       RABBITMQ_USERNAME: guest
       RABBITMQ_PASSWORD: guest
-      ANTIFRAUD_URL: http://antifraud_service_api:8080
-      NOTIFICATION_URL: http://notification_service_api:8080
+      ANTIFRAUD_URL: http://antifraud-service-api:8080
+      NOTIFICATION_URL: http://notification-service-api:8080
     deploy:
       resources:
         limits:
@@ -120,8 +120,8 @@ services:
       RABBITMQ_PORT: 5672
       RABBITMQ_USERNAME: guest
       RABBITMQ_PASSWORD: guest
-      ANTIFRAUD_URL: http://antifraud_service_api:8080
-      NOTIFICATION_URL: http://notification_service_api:8080
+      ANTIFRAUD_URL: http://antifraud-service-api:8080
+      NOTIFICATION_URL: http://notification-service-api:8080
     deploy:
       resources:
         limits:

--- a/monolith/banking-app-monolith/src/main/java/com/tcc/banking_app_monolith/app/dto/request/AccountPaymentRequestDto.java
+++ b/monolith/banking-app-monolith/src/main/java/com/tcc/banking_app_monolith/app/dto/request/AccountPaymentRequestDto.java
@@ -11,6 +11,6 @@ public record AccountPaymentRequestDto(
         Long accountId,
         @NotNull(message = "Amount cannot be null")
         BigDecimal amount,
-        @NotBlank(message = "Transaction type cannot be blank")
+        @NotNull(message = "Transaction type cannot be blank")
         TransactionType transactionType
 ) {}

--- a/monolith/banking-app-monolith/src/main/java/com/tcc/banking_app_monolith/app/service/impl/CreditPaymentProcessor.java
+++ b/monolith/banking-app-monolith/src/main/java/com/tcc/banking_app_monolith/app/service/impl/CreditPaymentProcessor.java
@@ -6,7 +6,9 @@ import com.tcc.banking_app_monolith.domain.entity.Account;
 import com.tcc.banking_app_monolith.domain.entity.Card;
 import com.tcc.banking_app_monolith.domain.enums.TransactionType;
 import com.tcc.banking_app_monolith.utils.Constants;
+import org.springframework.stereotype.Component;
 
+@Component
 public class CreditPaymentProcessor implements PaymentProcessor {
 
     @Override

--- a/monolith/banking-app-monolith/src/main/resources/application-local.yml
+++ b/monolith/banking-app-monolith/src/main/resources/application-local.yml
@@ -12,8 +12,14 @@ spring:
     hibernate:
       ddl-auto: update
 
+rabbitmq:
+  host: localhost
+  port: 5672
+  username: guest
+  password: guest
+
 notification:
-  url:
+  url: http://localhost:8083
 
 antifraud:
-  url:
+  url: http://localhost:8084

--- a/notification-service/src/main/java/com/tcc/notification_service/notification/NotificationImpl.java
+++ b/notification-service/src/main/java/com/tcc/notification_service/notification/NotificationImpl.java
@@ -1,5 +1,8 @@
 package com.tcc.notification_service.notification;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class NotificationImpl implements Notification {
 
     @Override


### PR DESCRIPTION
This pull request introduces several improvements and fixes across service configuration, DTO validation, and Spring component registration. The main changes include correcting service URLs in environment variables, updating validation annotations for request DTOs, and adding `@Component` annotations to service classes to enable Spring dependency injection.

**Configuration updates:**

* Updated `ANTIFRAUD_URL` and `NOTIFICATION_URL` environment variables in `docker-compose.yml` to use hyphenated service names, ensuring consistency with actual service container names. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L31-R32) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L123-R124)
* Added RabbitMQ and service URLs to `application-local.yml` for easier local development and configuration management.

**Validation improvements:**

* Changed the validation annotation for `transactionType` in `AccountPaymentRequestDto` from `@NotBlank` to `@NotNull`, which is more appropriate for enum types.

**Spring component registration:**

* Added the `@Component` annotation to `CreditPaymentProcessor` and `NotificationImpl` classes to ensure they are registered as Spring beans, enabling dependency injection. [[1]](diffhunk://#diff-1fe45e795272f2c40f594a7fa693e39a675b08d244c2db4eb76c3465e89f212cR9-R11) [[2]](diffhunk://#diff-ec50e216dc80699178a3cfa4495b6af4e5c52f72f2795fcd803b5bcad3d73097R3-R5)

**Other configuration cleanup:**

* Removed the explicit `server.port` setting from `antifraud-service`'s `application.yml`, likely to rely on default or external configuration instead.