### PR TITLE
fix: update docker-compose to add InfluxDB and adjust K6 configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -254,7 +254,7 @@ services:
     container_name: mongo-express
     restart: always
     ports:
-      - "8086:8081"
+      - "8087:8081"
     environment:
       ME_CONFIG_MONGODB_ADMINUSERNAME: root
       ME_CONFIG_MONGODB_ADMINPASSWORD: example
@@ -292,25 +292,31 @@ services:
       - "6565:6565"
     depends_on:
       - banking-microservice-account
+      - influxdb
     networks:
       - microservice-network
       - monolith-network
     volumes:
       - ./microservices/account-service/src/test/java/com/architecture/account_service/k6:/scripts
     entrypoint: ["tail", "-f", "/dev/null"]
+    environment:
+      K6_OUT: "influxdb=http://influxdb:8086/k6_metrics"
+      INFLUXDB_USER: "admin"
+      INFLUXDB_PASSWORD: "admin123"
 
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: prometheus
+  influxdb:
+    image: influxdb:1.8-alpine
+    container_name: influxdb
     ports:
-      - "9090:9090"
-    depends_on:
-      - k6
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - "8086:8086"
+    environment:
+      - INFLUXDB_DB=k6_metrics
+      - INFLUXDB_ADMIN_USER=admin
+      - INFLUXDB_ADMIN_PASSWORD=admin123
     networks:
       - microservice-network
       - monolith-network
+
 
   grafana:
     image: grafana/grafana:latest
@@ -320,6 +326,8 @@ services:
     networks:
       - microservice-network
       - monolith-network
+    volumes:
+      - grafana-storage:/var/lib/grafana
 
 networks:
   microservice-network:
@@ -332,3 +340,4 @@ volumes:
     driver: local
   mongo_data:
   redis_data:
+  grafana-storage:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,8 +1,0 @@
-global:
-  scrape_interval: 5s
-  evaluation_interval: 5s
-
-scrape_configs:
-  - job_name: 'k6'
-    static_configs:
-      - targets: ['k6:6565']


### PR DESCRIPTION
This pull request updates the monitoring and metrics stack in the `docker-compose.yml` configuration by replacing Prometheus with InfluxDB for storing k6 load test metrics, and ensures persistent storage for Grafana dashboards. The main changes involve service configuration updates, environment variable additions, and storage improvements.

Monitoring stack changes:

* Removed the Prometheus service and its configuration file, and added an InfluxDB service for metrics storage, including necessary environment variables for database and authentication. (`docker-compose.yml`, `prometheus.yml`) [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R295-R320) [[2]](diffhunk://#diff-eba10c79a11780b63d9a250b66db8322ca19e6d2f6c6b3ac0f57d512b88cab7fL1-L8)
* Updated the k6 service to depend on InfluxDB and configured it to output metrics to InfluxDB using new environment variables for connection and authentication. (`docker-compose.yml`)

Service configuration updates:

* Changed the exposed port for the `mongo-express` service from `8086` to `8087` to avoid port conflicts with InfluxDB. (`docker-compose.yml`)

Storage improvements:

* Added a persistent volume for Grafana to ensure dashboard data is retained across container restarts. (`docker-compose.yml`) [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R329-R330) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R343)